### PR TITLE
Dev.group by

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ generator_type = MultinomialField
 field_name = <FIELD_NAME>
 absolute_threshold = 10
 relative_threshold = 0.1
+group_by = None # this is an optional field
 
 [LG_TEXT]
 generator_type = TextField
@@ -91,6 +92,7 @@ generator_type = MultinomialFieldCombiner
 field_names = ['<FIELD_1>', '<FIELD_2>', ...]
 absolute_threshold = 10
 relative_threshold = 0.1
+group_by = None # this is an optional field
 
 [LG_KEYWORD]
 generator_type = KeywordBased
@@ -151,7 +153,7 @@ Params:
 * ***ngram_range:*** N-gram range to use for computation
 
 **MultinomialField**
-* This type of LabelGenerator handles fields with discreet value sets. It computes the probability of seeing a specific value and alerts based on relative and absolute thresholds.
+* This type of LabelGenerator handles fields with discreet value sets. It computes the probability of seeing a specific value and alerts based on relative and absolute thresholds. If `group_by` is specified, this label generator will compute statistics for target values by first creating buckets.
 
 Params
 * ***field_name:*** What field to use
@@ -159,7 +161,7 @@ Params
 * ***relative_threshold:*** Minimum relative value for occurrences to trigger alert for
 
 **MultinomialFieldCombiner**
-* This type of LabelGenerator handles fields with discreet value sets and build advanced features by combining values across the same dataset entry. It computes the probability of seeing a specific value and alerts based on relative and absolute thresholds.
+* This type of LabelGenerator handles fields with discreet value sets and build advanced features by combining values across the same dataset entry. It computes the probability of seeing a specific value and alerts based on relative and absolute thresholds.  If `group_by` is specified, this label generator will compute statistics for target values by first creating buckets.
 
 Params
 * ***field_names:*** What fields to combine

--- a/osas/io_utils/config.py
+++ b/osas/io_utils/config.py
@@ -110,6 +110,8 @@ class MultinomialField(Config):
     field_name: str = field(default='user')
     absolute_threshold: int = field(default=10)
     relative_threshold: float = field(default=0.1)
+    group_by: str = field(default=None)
+
 
 @dataclass
 class LOLField(Config):
@@ -128,6 +130,7 @@ class MultinomialFieldCombiner(Config):
     field_names: list = field(default_factory=lambda: [])
     absolute_threshold: float = field(default=500)
     relative_threshold: float = field(default=0.005)
+    group_by: str = field(default=None)
 
 
 @dataclass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added `group_by` optional attribute for MultinomialField and MultinomialFieldCombiner. This will allow OSAS to compute relative statistics instead of global. For instance, the value of the pair (USER, ASN) (you can imagine what this means) might be rare when compared to an entire dataset, but if you factor in something like ACCOUNT_ID (again, try to imagine what this does), then it might not be that rare.

<!--- Describe your changes in detail -->

## Related Issue

This should fix #10 .

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It provides better anomaly estimates for multinomial values, by enabling the user to configure `group_by` values.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [-] I have added tests to cover my changes.
- [x] All new and existing tests passed.
