### PR TITLE
merge functionality - MultinomialFieldCombiner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 dist/
 build/
-tests/
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 corpus/

--- a/src/osas/api.py
+++ b/src/osas/api.py
@@ -143,7 +143,7 @@ class OSAS:
 if __name__ == '__main__':
     cfg = OSASConfig.from_file('tests/model.conf')
     print(cfg.md5())
-    mdl = OSASPretrainedModel.from_file('tests/model.json'
+    mdl = OSASPretrainedModel.from_file('tests/model.json')
     print(mdl.md5())
     time_start = time.time()
     osas = OSAS.get_instance(cfg, mdl)

--- a/src/osas/api.py
+++ b/src/osas/api.py
@@ -127,7 +127,7 @@ class OSAS:
 if __name__ == '__main__':
     cfg = OSASConfig.from_file('tests/model.conf')
     print(cfg.md5())
-    mdl = OSASPretrainedModel.from_file('tests/model.json')
+    mdl = OSASPretrainedModel.from_file('tests/model.json'
     print(mdl.md5())
     time_start = time.time()
     osas = OSAS.get_instance(cfg, mdl)

--- a/src/osas/core/label_generators.py
+++ b/src/osas/core/label_generators.py
@@ -737,7 +737,7 @@ class MultinomialFieldCombiner(LabelGenerator):
     def compute_probabilities(self, group_by_field: Optional[Any], pair2count: dict) -> dict:
         pair2prob = {}
         if group_by_field is None:
-            total = pair2count.get('TOTAL', 1)  # Use the TOTAL from pair2count
+            total = pair2count.get('TOTAL', 1)
             for key in pair2count:
                 pair2prob[key] = pair2count[key] / total
         else:

--- a/src/osas/core/label_generators.py
+++ b/src/osas/core/label_generators.py
@@ -733,6 +733,22 @@ class MultinomialFieldCombiner(LabelGenerator):
 
         self._model['grand_total'] = self._model.get('grand_total', 0) + total
 
+
+    def compute_probabilities(self, group_by_field: Optional[Any], pair2count: dict) -> dict:
+        pair2prob = {}
+        if group_by_field is None:
+            total = pair2count.get('TOTAL', 1)  # Use the TOTAL from pair2count
+            for key in pair2count:
+                pair2prob[key] = pair2count[key] / total
+        else:
+            pair2count = self._model['pair2count']
+            for k1 in pair2count:
+                pair2prob[k1] = {}
+                total = int(pair2count[k1]['TOTAL'])
+                for key in pair2count[k1]:
+                    pair2prob[k1][key] = pair2count[k1][key] / total
+        return pair2prob
+
     def build_model(self, dataset: Datasource, count_column: str = None) -> dict:
         pair2count = self._model['pair2count']  # this is used for incremental updates
         group_by_field = self._model['group_by']
@@ -752,17 +768,7 @@ class MultinomialFieldCombiner(LabelGenerator):
         total, global_counter, group_counters, group_totals = self._reduce_results(results)
         self._merge_counts(total, global_counter, group_counters, group_totals, group_by_field)
 
-        pair2prob = {}
-        if group_by_field is None:
-            for key in pair2count:
-                pair2prob[key] = pair2count[key] / total
-        else:
-            pair2count = self._model['pair2count']
-            for k1 in pair2count:
-                pair2prob[k1] = {}
-                total = int(pair2count[k1]['TOTAL'])
-                for key in pair2count[k1]:
-                    pair2prob[k1][key] = pair2count[k1][key] / total
+        pair2prob = self.compute_probabilities(group_by_field, pair2count)
 
         self._model['pair2count'] = pair2count
         self._model['pair2prob'] = pair2prob
@@ -809,6 +815,50 @@ class MultinomialFieldCombiner(LabelGenerator):
         lg = MultinomialFieldCombiner()
         lg._model = json.loads(pretrained)
         return lg
+
+    def merge(self, generators: list['MultinomialFieldCombiner']) -> None:
+        """
+        Merge multiple MultinomialFieldCombiner instances into this one.
+        :param generators: List of MultinomialFieldCombiner instances to merge.
+        """
+        for gen in generators:
+            if not isinstance(gen, MultinomialFieldCombiner):
+                raise ValueError("All generators must be instances of MultinomialFieldCombiner")
+            
+            # Check model compatibility
+            if (self._model['field_names'] != gen._model['field_names'] or
+                self._model['group_by'] != gen._model['group_by']):
+                raise ValueError("Cannot merge generators with different field_names or group_by configurations")
+            
+            # Merge pair2count structures
+            self._merge_pair2count(gen._model['pair2count'])
+            
+            # Update grand total
+            self._model['grand_total'] = self._model.get('grand_total', 0) + gen._model.get('grand_total', 0)
+        
+        # Recalculate probabilities after all merges are complete
+        self._model['pair2prob'] = self.compute_probabilities(self._model['group_by'], self._model['pair2count'])
+
+    def _merge_pair2count(self, other_pair2count: dict) -> None:
+        """
+        Helper method to merge pair2count structures, handling both flat and nested cases.
+        """
+        current_pair2count = self._model['pair2count']
+        group_by = self._model['group_by']
+        
+        if group_by is None:
+            # Flat structure: direct key-value pairs
+            for key, count in other_pair2count.items():
+                current_pair2count[key] = current_pair2count.get(key, 0) + count
+        else:
+            # Nested structure: group_by_value -> {pair -> count}
+            for group_value, group_counts in other_pair2count.items():
+                if group_value not in current_pair2count:
+                    current_pair2count[group_value] = {}
+                for key, count in group_counts.items():
+                    current_pair2count[group_value][key] = current_pair2count[group_value].get(key, 0) + count
+
+    
 
 
 class NumericalFieldCombiner(LabelGenerator):

--- a/src/osas/tests/__init__.py
+++ b/src/osas/tests/__init__.py
@@ -1,0 +1,1 @@
+# OSAS Tests Module

--- a/src/osas/tests/test_label_generators.py
+++ b/src/osas/tests/test_label_generators.py
@@ -1,0 +1,297 @@
+"""
+Unit tests for MultinomialFieldCombiner class.
+
+Tests basic functionality and merge operation of the MultinomialFieldCombiner
+which handles fields with discrete value sets and builds advanced features
+by combining values across the same dataset entry.
+"""
+
+import unittest
+import json
+from collections import Counter, defaultdict
+from typing import Dict, Any, List
+
+from osas.core.label_generators import MultinomialFieldCombiner
+from osas.core.interfaces import Datasource
+
+
+class MockDatasource(Datasource):
+    """Simple mock datasource for testing"""
+    
+    def __init__(self, data: List[Dict[str, Any]]):
+        self._data = data
+    
+    def __len__(self) -> int:
+        return len(self._data)
+    
+    def __getitem__(self, index: int) -> dict:
+        return self._data[index]
+    
+    def __setitem__(self, key: str, value: Any):
+        # Not needed for these tests
+        pass
+    
+    def apply(self, func, axis: int = 0) -> List[Any]:
+        """Apply function to each row"""
+        return [func(item) for item in self._data]
+    
+    def save(self, file_handle) -> None:
+        # Not needed for these tests
+        pass
+    
+    def groupby(self, column_name: str, agg_func):
+        # Not needed for these tests
+        pass
+
+
+class TestMultinomialFieldCombiner(unittest.TestCase):
+    """Test cases for MultinomialFieldCombiner functionality"""
+    
+    def setUp(self):
+        """Set up test fixtures"""
+        self.test_data = [
+            {'user': 'alice', 'action': 'login', 'host': 'server1'},
+            {'user': 'alice', 'action': 'login', 'host': 'server1'},
+            {'user': 'alice', 'action': 'logout', 'host': 'server1'},
+            {'user': 'bob', 'action': 'login', 'host': 'server2'},
+            {'user': 'bob', 'action': 'login', 'host': 'server2'},
+            {'user': 'charlie', 'action': 'admin', 'host': 'server1'},
+        ]
+        self.mock_dataset = MockDatasource(self.test_data)
+    
+    def test_build_model_without_groupby(self):
+        """Test building model without group_by parameter"""
+        mfc = MultinomialFieldCombiner(['user', 'action'])
+        model = mfc.build_model(self.mock_dataset)
+        
+        # Check that model was built
+        self.assertIn('pair2count', model)
+        self.assertIn('pair2prob', model)
+        
+        # Check specific counts
+        pair2count = model['pair2count']
+        self.assertEqual(pair2count['(alice,login)'], 2)
+        self.assertEqual(pair2count['(alice,logout)'], 1)
+        self.assertEqual(pair2count['(bob,login)'], 2)
+        self.assertEqual(pair2count['(charlie,admin)'], 1)
+        self.assertEqual(pair2count['TOTAL'], 6)
+        
+        # Check specific probabilities
+        pair2prob = model['pair2prob']
+        self.assertAlmostEqual(pair2prob['(alice,login)'], 2/6, places=3)  # 2 out of 6 total
+        self.assertAlmostEqual(pair2prob['(alice,logout)'], 1/6, places=3)  # 1 out of 6 total
+        self.assertAlmostEqual(pair2prob['(bob,login)'], 2/6, places=3)  # 2 out of 6 total
+        self.assertAlmostEqual(pair2prob['(charlie,admin)'], 1/6, places=3)  # 1 out of 6 total
+        self.assertAlmostEqual(pair2prob['TOTAL'], 1.0, places=3)  # TOTAL should be 1.0
+    
+    def test_build_model_with_groupby(self):
+        """Test building model with group_by parameter"""
+        mfc = MultinomialFieldCombiner(['user', 'action'], group_by='host')
+        model = mfc.build_model(self.mock_dataset)
+        
+        # Check grouped structure
+        pair2count = model['pair2count']
+        pair2prob = model['pair2prob']
+        self.assertIn('server1', pair2count)
+        self.assertIn('server2', pair2count)
+        self.assertIn('server1', pair2prob)
+        self.assertIn('server2', pair2prob)
+        
+        # Check server1 group counts
+        self.assertEqual(pair2count['server1']['(alice,login)'], 2)
+        self.assertEqual(pair2count['server1']['(alice,logout)'], 1)
+        self.assertEqual(pair2count['server1']['(charlie,admin)'], 1)
+        self.assertEqual(pair2count['server1']['TOTAL'], 4)
+        
+        # Check server1 group probabilities
+        self.assertAlmostEqual(pair2prob['server1']['(alice,login)'], 2/4, places=3)  # 2 out of 4 in server1
+        self.assertAlmostEqual(pair2prob['server1']['(alice,logout)'], 1/4, places=3)  # 1 out of 4 in server1
+        self.assertAlmostEqual(pair2prob['server1']['(charlie,admin)'], 1/4, places=3)  # 1 out of 4 in server1
+        self.assertAlmostEqual(pair2prob['server1']['TOTAL'], 1.0, places=3)  # TOTAL should be 1.0
+        
+        # Check server2 group counts
+        self.assertEqual(pair2count['server2']['(bob,login)'], 2)
+        self.assertEqual(pair2count['server2']['TOTAL'], 2)
+        
+        # Check server2 group probabilities
+        self.assertAlmostEqual(pair2prob['server2']['(bob,login)'], 2/2, places=3)  # 2 out of 2 in server2
+        self.assertAlmostEqual(pair2prob['server2']['TOTAL'], 1.0, places=3)  # TOTAL should be 1.0
+    
+    def test_call_method_without_groupby(self):
+        """Test the __call__ method without group_by"""
+        mfc = MultinomialFieldCombiner(['user', 'action'], absolute_threshold=2, relative_threshold=0.25)
+        mfc.build_model(self.mock_dataset)
+        
+        # Test seen combination with sufficient count and probability
+        labels = mfc({'user': 'alice', 'action': 'login'})
+        self.assertEqual(labels, [])  # Should not trigger any alerts
+        
+        # Test seen combination with low count
+        labels = mfc({'user': 'charlie', 'action': 'admin'})
+        self.assertIn('LOW_OBS_COUNT_FOR_USER_ACTION_PAIR', labels)
+        
+        # Test unseen combination
+        labels = mfc({'user': 'dave', 'action': 'delete'})
+        self.assertEqual(labels, ['UNSEEN_USER_ACTION_PAIR'])
+    
+    def test_call_method_with_groupby(self):
+        """Test the __call__ method with group_by"""
+        mfc = MultinomialFieldCombiner(['user', 'action'], group_by='host', absolute_threshold=2, relative_threshold=0.4)
+        mfc.build_model(self.mock_dataset)
+        
+        # Test seen combination in existing group
+        labels = mfc({'user': 'alice', 'action': 'login', 'host': 'server1'})
+        self.assertEqual(labels, [])  # Should not trigger alerts
+        
+        # Test seen combination with low count in group
+        labels = mfc({'user': 'charlie', 'action': 'admin', 'host': 'server1'})
+        self.assertIn('LOW_OBS_COUNT_FOR_USER_ACTION_PAIR_BASED_ON_HOST', labels)
+        
+        # Test combination in unseen group
+        labels = mfc({'user': 'alice', 'action': 'login', 'host': 'server3'})
+        self.assertEqual(labels, [])  # Empty for unseen group
+    
+    def test_merge_functionality_without_groupby(self):
+        """Test merge functionality without group_by"""
+        # Create first combiner with some data
+        mfc1 = MultinomialFieldCombiner(['user', 'action'])
+        data1 = [
+            {'user': 'alice', 'action': 'login'},
+            {'user': 'alice', 'action': 'login'},
+            {'user': 'bob', 'action': 'logout'}
+        ]
+        mfc1.build_model(MockDatasource(data1))
+        
+        # Create second combiner with different data
+        mfc2 = MultinomialFieldCombiner(['user', 'action'])
+        data2 = [
+            {'user': 'alice', 'action': 'login'},
+            {'user': 'charlie', 'action': 'admin'}
+        ]
+        mfc2.build_model(MockDatasource(data2))
+        
+        # Merge the second into the first
+        mfc1.merge([mfc2])
+        
+        # Check merged counts
+        pair2count = mfc1._model['pair2count']
+        self.assertEqual(pair2count['(alice,login)'], 3)  # 2 + 1
+        self.assertEqual(pair2count['(bob,logout)'], 1)
+        self.assertEqual(pair2count['(charlie,admin)'], 1)
+        self.assertEqual(pair2count['TOTAL'], 5)  # 3 + 2
+        
+        # Check that grand_total was updated
+        self.assertEqual(mfc1._model['grand_total'], 5)
+        
+        # Check that probabilities were recalculated correctly after merge
+        pair2prob = mfc1._model['pair2prob']
+        self.assertAlmostEqual(pair2prob['(alice,login)'], 3/5, places=3)  # 3 out of 5 total
+        self.assertAlmostEqual(pair2prob['(bob,logout)'], 1/5, places=3)  # 1 out of 5 total
+        self.assertAlmostEqual(pair2prob['(charlie,admin)'], 1/5, places=3)  # 1 out of 5 total
+    
+    def test_merge_functionality_with_groupby(self):
+        """Test merge functionality with group_by"""
+        # Create first combiner with grouped data
+        mfc1 = MultinomialFieldCombiner(['user', 'action'], group_by='host')
+        data1 = [
+            {'user': 'alice', 'action': 'login', 'host': 'server1'},
+            {'user': 'alice', 'action': 'login', 'host': 'server1'},
+            {'user': 'bob', 'action': 'logout', 'host': 'server2'}
+        ]
+        mfc1.build_model(MockDatasource(data1))
+        
+        # Create second combiner with overlapping groups
+        mfc2 = MultinomialFieldCombiner(['user', 'action'], group_by='host')
+        data2 = [
+            {'user': 'alice', 'action': 'login', 'host': 'server1'},
+            {'user': 'charlie', 'action': 'admin', 'host': 'server3'}
+        ]
+        mfc2.build_model(MockDatasource(data2))
+        
+        # Merge the second into the first
+        mfc1.merge([mfc2])
+        
+        # Check merged counts
+        pair2count = mfc1._model['pair2count']
+        
+        # Check server1 group (should be merged)
+        self.assertEqual(pair2count['server1']['(alice,login)'], 3)  # 2 + 1
+        self.assertEqual(pair2count['server1']['TOTAL'], 3)  # 2 + 1
+        
+        # Check server2 group (unchanged)
+        self.assertEqual(pair2count['server2']['(bob,logout)'], 1)
+        self.assertEqual(pair2count['server2']['TOTAL'], 1)
+        
+        # Check server3 group (new)
+        self.assertEqual(pair2count['server3']['(charlie,admin)'], 1)
+        self.assertEqual(pair2count['server3']['TOTAL'], 1)
+        
+        # Check that probabilities were recalculated correctly after merge
+        pair2prob = mfc1._model['pair2prob']
+        
+        # Server1 probabilities after merge
+        self.assertAlmostEqual(pair2prob['server1']['(alice,login)'], 3/3, places=3)  # 3 out of 3 in server1
+        self.assertAlmostEqual(pair2prob['server1']['TOTAL'], 1.0, places=3)
+        
+        # Server2 probabilities (unchanged)
+        self.assertAlmostEqual(pair2prob['server2']['(bob,logout)'], 1/1, places=3)  # 1 out of 1 in server2
+        self.assertAlmostEqual(pair2prob['server2']['TOTAL'], 1.0, places=3)
+        
+        # Server3 probabilities (new)
+        self.assertAlmostEqual(pair2prob['server3']['(charlie,admin)'], 1/1, places=3)  # 1 out of 1 in server3
+        self.assertAlmostEqual(pair2prob['server3']['TOTAL'], 1.0, places=3)
+    
+    def test_merge_incompatible_generators(self):
+        """Test merge with incompatible generators raises error"""
+        mfc1 = MultinomialFieldCombiner(['user', 'action'])
+        mfc2 = MultinomialFieldCombiner(['user', 'host'])  # Different field names
+        
+        mfc1.build_model(MockDatasource(self.test_data[:2]))
+        mfc2.build_model(MockDatasource(self.test_data[:2]))
+        
+        with self.assertRaises(ValueError):
+            mfc1.merge([mfc2])
+    
+    def test_from_pretrained(self):
+        """Test loading from pretrained model"""
+        mfc = MultinomialFieldCombiner(['user', 'action'])
+        mfc.build_model(self.mock_dataset)
+        
+        # Serialize the model
+        model_json = json.dumps(mfc._model)
+        
+        # Load from pretrained
+        mfc_loaded = MultinomialFieldCombiner.from_pretrained(model_json)
+        
+        # Check that the models are equivalent
+        self.assertEqual(mfc._model['field_names'], mfc_loaded._model['field_names'])
+        self.assertEqual(mfc._model['pair2count'], mfc_loaded._model['pair2count'])
+        self.assertEqual(mfc._model['absolute_threshold'], mfc_loaded._model['absolute_threshold'])
+        self.assertEqual(mfc._model['relative_threshold'], mfc_loaded._model['relative_threshold'])
+    
+    def test_with_count_column(self):
+        """Test building model with count column"""
+        data_with_counts = [
+            {'user': 'alice', 'action': 'login', 'count': 5},
+            {'user': 'bob', 'action': 'logout', 'count': 3},
+            {'user': 'alice', 'action': 'login', 'count': 2}
+        ]
+        
+        mfc = MultinomialFieldCombiner(['user', 'action'])
+        model = mfc.build_model(MockDatasource(data_with_counts), count_column='count')
+        
+        # Check that counts were properly aggregated
+        pair2count = model['pair2count']
+        self.assertEqual(pair2count['(alice,login)'], 7)  # 5 + 2
+        self.assertEqual(pair2count['(bob,logout)'], 3)
+        self.assertEqual(pair2count['TOTAL'], 10)  # 5 + 3 + 2
+        
+        # Check that probabilities were calculated correctly with count column
+        pair2prob = model['pair2prob']
+        self.assertAlmostEqual(pair2prob['(alice,login)'], 7/10, places=3)  # 7 out of 10 total
+        self.assertAlmostEqual(pair2prob['(bob,logout)'], 3/10, places=3)  # 3 out of 10 total
+        self.assertAlmostEqual(pair2prob['TOTAL'], 1.0, places=3)  # TOTAL should be 1.0
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces `merge functionality` for MultinomialFieldCombiner label generator.

`Merge`: having multiple MultinomialFieldCombiner label generators applied on sections of the dataset, merge them together into an unified model.


<!--- Describe your changes in detail -->

The method `merge` adds together pair2count dictionaries of models and then recomputes pair2prob.
It also checks for `compatibility between the models`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Motivation and Context

This is to enable concurrent training: the label generator can be now applied separately, in parallel, on spark partitions.
To enable end2end parallel training, the remaining label generators should also implement this approach.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Introduced a new set of unit tests, covering basic functionality of the generator, on a mock dataset, including merging capabilities.

`python -m unittest src.osas.tests.test_label_generators -v`

This file is to be extended to other supported label generators.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
