### PR TITLE
merge functionality for textfield

### DIFF
--- a/src/osas/core/label_generators.py
+++ b/src/osas/core/label_generators.py
@@ -30,6 +30,7 @@ from osas.core.utils import Tokenizer
 from enum import Enum
 from typing import Any, Dict, Iterable, Optional, Tuple
 from collections import Counter, defaultdict
+import warnings
 
 
 # from lol.api import LOLC
@@ -633,6 +634,12 @@ class TextField(LabelGenerator):
         :param generators: List of TextField instances to merge.
         """
         total_inf = self._total_inf
+
+        warnings.warn(
+            "Not implemented carefully, you need to call compute_statistics() after merging on the full dataset for new perplexity based score thresholds.",
+            UserWarning,
+            stacklevel=2
+        )
 
         for gen in generators:
             if not isinstance(gen, TextField):

--- a/src/osas/core/label_generators.py
+++ b/src/osas/core/label_generators.py
@@ -533,6 +533,11 @@ class TextField(LabelGenerator):
 
         return ngram2count, total_inf
 
+    def compute_perplexity_func(self, item):
+            text = item[self._field_name]
+            perplexity = self._compute_perplexity(text)
+            return perplexity
+
     def build_model(self, dataset: Datasource, count_column: str = None) -> dict:
         unigram2count, _ = self.build_ngram2count(dataset, count_column, unigrams_only=True)
         for unigram in unigram2count:
@@ -546,15 +551,9 @@ class TextField(LabelGenerator):
         ser_model = [self._field_name, self._lm_mode, self._ngram_range[0], self._ngram_range[1], self._mean_perplex,
                      self._std_perplex, self._total_inf]
 
-        def compute_perplexity_func(item):
-            text = item[self._field_name]
-            perplexity = self._compute_perplexity(text)
-            return perplexity
+        
 
-        all_perplex = dataset.apply(compute_perplexity_func, axis=1)
-
-        self._mean_perplex = np.mean(all_perplex)
-        self._std_perplex = np.std(all_perplex)
+        self.compute_statistics(dataset)
         ser_model[4] = self._mean_perplex
         ser_model[5] = self._std_perplex
         ser_model.append(self._accepted_unigrams)
@@ -583,7 +582,7 @@ class TextField(LabelGenerator):
         elif perplexity - self._mean_perplex < 4 * self._std_perplex:
             return ['{0}_HIGH_PERPLEXITY'.format(self._field_name.upper()), perplexity * 10]
         else:
-            return ['{0}_EXTREEME_PERPLEXITY'.format(self._field_name.upper()), perplexity * 10]
+            return ['{0}_EXTREME_PERPLEXITY'.format(self._field_name.upper()), perplexity * 10]
 
     @staticmethod
     def from_pretrained(pretrained: str) -> LabelGenerator:
@@ -627,6 +626,39 @@ class TextField(LabelGenerator):
                 ngram = tuple(toks[ii:ii + ngram_order])
                 ngrams.append(ngram)
         return ngrams
+
+    def merge(self, generators: list['TextField']) -> None:
+        """
+        Merge multiple TextField instances into this one.
+        :param generators: List of TextField instances to merge.
+        """
+        total_inf = self._total_inf
+
+        for gen in generators:
+            if not isinstance(gen, TextField):
+                continue
+
+            # merge ngram2count
+            for ngram in gen._model:
+                if ngram in self._model:
+                    self._model[ngram] += gen._model[ngram]
+                else:
+                    self._model[ngram] = gen._model[ngram]
+
+            # merge accepted unigrams
+            for unigram in gen._accepted_unigrams:
+                if unigram not in self._accepted_unigrams:
+                    self._accepted_unigrams[unigram] = 1
+
+            # merge total_inf
+            total_inf += gen._total_inf
+        self._total_inf = total_inf
+
+    def compute_statistics(self, dataset: Datasource) -> None:
+        all_perplex = dataset.apply(self.compute_perplexity_func, axis=1)
+        self._mean_perplex = float(np.mean(all_perplex)) if len(all_perplex) > 0 else 0.0
+        self._std_perplex = float(np.std(all_perplex)) if len(all_perplex) > 0 else 0.0
+
 
 
 class MultinomialField(LabelGenerator):

--- a/src/osas/tests/test_textfield.py
+++ b/src/osas/tests/test_textfield.py
@@ -266,6 +266,73 @@ class TestTextField(unittest.TestCase):
         self.assertTrue(all(len(ngram) == 2 for ngram in single_ngrams), "Should only generate bigrams")
         self.assertEqual(len(single_ngrams), 3, "Should generate exactly 3 bigrams")
 
+    def test_merge_behavior_combined(self):
+        """Test TextField.merge by comparing with a combined dataset baseline"""
+        # Two separate datasets with enough repetition to ensure unigrams are accepted consistently
+        data_a = [
+            {'command': 'ls -la'},
+            {'command': 'ls -la'},
+            {'command': 'ls -la'},
+            {'command': 'cat file.txt'},
+            {'command': 'cat file.txt'},
+            {'command': 'cat file.txt'},
+        ]
+        data_b = [
+            {'command': 'ls -la'},
+            {'command': 'ls -la'},
+            {'command': 'ls -la'},
+            {'command': 'grep error'},
+            {'command': 'grep error'},
+            {'command': 'grep error'},
+        ]
+
+        dataset_a = MockDatasource(data_a)
+        dataset_b = MockDatasource(data_b)
+        
+        combined_data = data_a + data_b
+        dataset_combined = MockDatasource(combined_data)
+        
+        # Build separate models and merge
+        tf_a = TextField('command', lm_mode='token', ngram_range=(2, 3))
+        tf_b = TextField('command', lm_mode='token', ngram_range=(2, 3))
+        tf_a.build_model(dataset_a)
+        tf_b.build_model(dataset_b)
+        tf_a.merge([tf_b])
+        tf_a.compute_statistics(dataset_combined)
+        
+        # Build baseline model on combined dataset
+        tf_baseline = TextField('command', lm_mode='token', ngram_range=(2, 3))
+        tf_baseline.build_model(dataset_combined)
+        
+        # Compare key properties
+        self.assertEqual(tf_a._total_inf, tf_baseline._total_inf, "Total inference counts should match")
+        
+        # N-gram counts should be identical for shared patterns
+        test_ngrams = [('ls', '-'), ('ls', '-', 'la'), ('grep', 'error')]
+        for ngram in test_ngrams:
+            if ngram in tf_a._model and ngram in tf_baseline._model:
+                self.assertEqual(tf_a._model[ngram], tf_baseline._model[ngram], 
+                               f"N-gram count for {ngram} should match")
+        
+        # Accepted unigrams should be the same
+        self.assertEqual(set(tf_a._accepted_unigrams.keys()), 
+                        set(tf_baseline._accepted_unigrams.keys()),
+                        "Accepted unigrams should match")
+        
+        # Mean and standard deviation should match
+        self.assertAlmostEqual(tf_a._mean_perplex, tf_baseline._mean_perplex, places=6,
+                              msg="Mean perplexity should match between merged and baseline models")
+        self.assertAlmostEqual(tf_a._std_perplex, tf_baseline._std_perplex, places=6,
+                              msg="Standard deviation should match between merged and baseline models")
+        
+        # Test that merge ignores non-TextField objects
+        tf_test = TextField('command', lm_mode='token', ngram_range=(2, 3))
+        tf_test.build_model(dataset_a)
+        original_total = tf_test._total_inf
+        tf_test.merge([tf_b, "not_a_textfield", 123, None])
+        self.assertEqual(tf_test._total_inf, tf_a._total_inf, 
+                        "Should ignore non-TextField objects in merge list")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/osas/tests/test_textfield.py
+++ b/src/osas/tests/test_textfield.py
@@ -328,7 +328,6 @@ class TestTextField(unittest.TestCase):
         # Test that merge ignores non-TextField objects
         tf_test = TextField('command', lm_mode='token', ngram_range=(2, 3))
         tf_test.build_model(dataset_a)
-        original_total = tf_test._total_inf
         tf_test.merge([tf_b, "not_a_textfield", 123, None])
         self.assertEqual(tf_test._total_inf, tf_a._total_inf, 
                         "Should ignore non-TextField objects in merge list")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces merge functionality for TextField label generator. 
It enables merging multiple TextField models trained on separate datasets into a single one, by aggregating the N-Gram information.

!!Limitation: The mean and standard deviation of the perplexity-based score are calculated using the N-Gram model trained on the subset; therefore, computing these statistics for the merged model requires recomputation on the full dataset using the merged N-Gram model.



## Motivation and Context

To enable efficient parallel training. See #32 .

## How Has This Been Tested?

Added test suite for merge capability, compares separately trained and merged models with model trained on combined corpus.

`python -m unittest src.osas.tests.test_textfield`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
